### PR TITLE
Update policy page and remove contact form references

### DIFF
--- a/src/content/faq/-index.md
+++ b/src/content/faq/-index.md
@@ -41,7 +41,7 @@ sections:
         answer: "No, but you can search for a roof over your head on:\n\n* [Nomadlist - Madeira](https://nomadlist.com/madeira)\n* [An Island Apart](https://www.anislandapart.com)\n* [Booking.com](https://www.booking.com)\n* [Airbnb](https://www.airbnb.com)\n\nThere's also [madeirafriends.org](https://madeirafriends.org) which is a community that can help with many things."
 
       - question: 'How do I need to prepare for the six weeks?'
-        answer: "There's of course a difference if you travel to Madeira on your own, or with a family. Besides this, your preparations should be approached like a longer than normal working holiday of six weeks. So, pack enough clothes and hardware that you'll be needing for living out of your suitcase for a while.\n\nIf you have special needs, please send us a message through the contact form and we'll see how we can help you settle in."
+        answer: "There's of course a difference if you travel to Madeira on your own, or with a family. Besides this, your preparations should be approached like a longer than normal working holiday of six weeks. So, pack enough clothes and hardware that you'll be needing for living out of your suitcase for a while.\n\nIf you have special needs, please reach out to us and we'll see how we can help you settle in."
 
   - id: 'cost-living'
     title: 'Cost of Living'

--- a/src/content/faq/-index.md
+++ b/src/content/faq/-index.md
@@ -35,7 +35,7 @@ sections:
     title: 'Travel & Accommodation'
     questions:
       - question: 'Do you pay for flights and accommodation?'
-        answer: "No, we don't. If you commit yourself to the program you have to organize your flights and accommodation yourself. If you, for any reason, are not able to do this, please send us a message via the contact form."
+        answer: "No, we don't. If you commit yourself to the program you have to organize your flights and accommodation yourself. If you, for any reason, are not able to do this, please reach out to us."
 
       - question: 'Do you provide accommodation?'
         answer: "No, but you can search for a roof over your head on:\n\n* [Nomadlist - Madeira](https://nomadlist.com/madeira)\n* [An Island Apart](https://www.anislandapart.com)\n* [Booking.com](https://www.booking.com)\n* [Airbnb](https://www.airbnb.com)\n\nThere's also [madeirafriends.org](https://madeirafriends.org) which is a community that can help with many things."

--- a/src/content/faq/-index.md
+++ b/src/content/faq/-index.md
@@ -56,7 +56,7 @@ sections:
         answer: 'Applications for SEC-05 are now closed. Stay tuned for future opportunities to join our community of builders.'
 
       - question: 'How do I best contact you?'
-        answer: "You can contact us via the contact form, via email [info@sovereignengineering.io](mailto:info@sovereignengineering.io), or via [nostr](https://njump.me/sovereignengineering.io). We'll do our best to get back to you as soon as possible."
+        answer: "You can contact us via email [info@sovereignengineering.io](mailto:info@sovereignengineering.io) or via [nostr](https://njump.me/sovereignengineering.io). We'll do our best to get back to you as soon as possible."
 
   - id: 'contact-info'
     title: 'Still Have Questions?'

--- a/src/pages/policy.astro
+++ b/src/pages/policy.astro
@@ -15,7 +15,7 @@ const page_title = "Policy";
         <div class="col-12 md:col-8 lg:col-6">
           <div class="text-center">
             <p class="text-lg" style="font-family: 'Courier New', monospace;">
-              We accept participants based on merit, public proof-of-work, and their alignment with our <a href="/philosophy" class="text-primary hover:underline">philosophy</a>. Anyone with an npub and a relevant public commit history is fair game.
+              We accept participants based on merit, public proof-of-work, and their alignment with our <a href="/philosophy" class="text-primary hover:underline">philosophy</a>. We welcome anyone with an npub and relevant public commit history.
             </p>
           </div>
         </div>

--- a/src/pages/policy.astro
+++ b/src/pages/policy.astro
@@ -17,6 +17,9 @@ const page_title = "Policy";
             <p class="text-lg" style="font-family: 'Courier New', monospace;">
               We accept participants based on merit, public proof-of-work, and their alignment with our <a href="/philosophy" class="text-primary hover:underline">philosophy</a>. We welcome anyone with an npub and relevant public commit history.
             </p>
+            <p class="text-lg" style="font-family: 'Courier New', monospace;">
+              We do not discriminate in our selection process based on race, ethnicity, creed, color, age, national origin, ancestry, religion, political opinion, gender, sexual orientation, gender identity, disability, genetic information, veteran status, military status, or any other such status.
+            </p>
           </div>
         </div>
       </div>

--- a/src/pages/policy.astro
+++ b/src/pages/policy.astro
@@ -15,7 +15,7 @@ const page_title = "Policy";
         <div class="col-12 md:col-8 lg:col-6">
           <div class="text-center">
             <p class="text-lg" style="font-family: 'Courier New', monospace;">
-              We accept anyone based on merit and their alignment with our <a href="/philosophy" class="text-primary hover:underline">PHILOSOPHY</a> page. Nothing else matters.
+              We accept anyone based on merit and their alignment with our <a href="/philosophy" class="text-primary hover:underline">philosophy</a> page. Nothing else matters.
             </p>
           </div>
         </div>

--- a/src/pages/policy.astro
+++ b/src/pages/policy.astro
@@ -15,7 +15,7 @@ const page_title = "Policy";
         <div class="col-12 md:col-8 lg:col-6">
           <div class="text-center">
             <p class="text-lg" style="font-family: 'Courier New', monospace;">
-              We are all adults. We accept anyone based on merit and their alignment with our <a href="/philosophy" class="text-primary hover:underline">PHILOSOPHY</a> page. Nothing else matters.
+              We accept anyone based on merit and their alignment with our <a href="/philosophy" class="text-primary hover:underline">PHILOSOPHY</a> page. Nothing else matters.
             </p>
           </div>
         </div>

--- a/src/pages/policy.astro
+++ b/src/pages/policy.astro
@@ -15,7 +15,7 @@ const page_title = "Policy";
         <div class="col-12 md:col-8 lg:col-6">
           <div class="text-center">
             <p class="text-lg" style="font-family: 'Courier New', monospace;">
-              We accept anyone based on merit and their alignment with our <a href="/philosophy" class="text-primary hover:underline">philosophy</a> page. Nothing else matters.
+              We accept participants based on merit, public proof-of-work, and their alignment with our <a href="/philosophy" class="text-primary hover:underline">philosophy</a>. Anyone with an npub and a relevant public commit history is fair game.
             </p>
           </div>
         </div>


### PR DESCRIPTION
This PR updates the policy page with a more comprehensive and professional statement about participant selection criteria, emphasizing merit, public proof-of-work, and philosophy alignment. It also adds a comprehensive non-discrimination statement. Additionally, all references to the non-existent contact form have been removed from the FAQ content and replaced with more appropriate contact methods.

- Updated policy page with merit-based selection criteria and npub requirements
- Added comprehensive non-discrimination statement to policy page  
- Removed all references to non-existent contact form from FAQ content