### PR TITLE
feat: add podcast link before why nav item

### DIFF
--- a/src/layouts/components/StickyNav.astro
+++ b/src/layouts/components/StickyNav.astro
@@ -15,6 +15,14 @@ const { main } = menu;
       </div>
 
       <div class="hidden md:flex items-center space-x-6">
+        <a
+          href="/podcast"
+          class="text-white hover:text-primary transition-colors text-xl leading-none"
+          aria-label="Podcast"
+          title="Podcast"
+        >
+          🎙️
+        </a>
         {
           main.map((menu) => {
             const isExternal = menu.url.startsWith('http') || menu.url.startsWith('mailto');


### PR DESCRIPTION
This adds a direct podcast shortcut to the sticky navigation by placing a microphone emoji link immediately before `Why?`. The change keeps the existing nav structure intact while making the podcast easier to reach from the main site flow.

- links the new icon directly to `/podcast`
- keeps the existing `Why? / What? / How?` entries unchanged
- passes `lint` and `build`
