### PR TITLE
Add per-cohort project pages with live Nostr demo gallery on SEC-07

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "@fontsource/im-fell-double-pica": "^5.2.6",
         "@fortawesome/fontawesome-free": "^7.0.0",
         "@justinribeiro/lite-youtube": "^1.8.2",
+        "applesauce-relay": "^5.2.0",
         "astro": "5.7.8",
         "astro-auto-import": "^0.4.4",
         "astro-fathom": "^2.0.0",
@@ -276,6 +277,12 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
 
+    "@noble/ciphers": ["@noble/ciphers@0.5.3", "", {}, "sha512-B0+6IIHiqEs3BPMT0hcRmHvEj2QHOLu+uwt+tqDDeVd0oyVzh7BPrDcPjRnV1PV/5LaknXJJQvOuRGR0zQJz+w=="],
+
+    "@noble/curves": ["@noble/curves@1.2.0", "", { "dependencies": { "@noble/hashes": "1.3.2" } }, "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw=="],
+
+    "@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
@@ -335,6 +342,12 @@
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.52.5", "", { "os": "win32", "cpu": "x64" }, "sha512-TAcgQh2sSkykPRWLrdyy2AiceMckNf5loITqXxFI5VuQjS5tSuw3WlwdN8qv8vzjLAUTvYaH/mVjSFpbkFbpTg=="],
 
     "@rtsao/scc": ["@rtsao/scc@1.1.0", "", {}, "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g=="],
+
+    "@scure/base": ["@scure/base@1.1.1", "", {}, "sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA=="],
+
+    "@scure/bip32": ["@scure/bip32@1.3.1", "", { "dependencies": { "@noble/curves": "~1.1.0", "@noble/hashes": "~1.3.1", "@scure/base": "~1.1.0" } }, "sha512-osvveYtyzdEVbt3OfwwXFr4P2iVBL5u1Q3q4ONBfDY/UpOuXmOlbgwc1xECEboY8wIays8Yt6onaWMUdUbfl0A=="],
+
+    "@scure/bip39": ["@scure/bip39@1.2.1", "", { "dependencies": { "@noble/hashes": "~1.3.0", "@scure/base": "~1.1.0" } }, "sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg=="],
 
     "@shikijs/core": ["@shikijs/core@3.13.0", "", { "dependencies": { "@shikijs/types": "3.13.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-3P8rGsg2Eh2qIHekwuQjzWhKI4jV97PhvYjYUzGqjvJfqdQPz+nMlfWahU24GZAyW1FxFI1sYjyhfh5CoLmIUA=="],
 
@@ -519,6 +532,10 @@
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
+
+    "applesauce-core": ["applesauce-core@5.2.0", "", { "dependencies": { "debug": "^4.4.0", "fast-deep-equal": "^3.1.3", "hash-sum": "^2.0.0", "nanoid": "^5.0.9", "nostr-tools": "~2.19", "rxjs": "^7.8.1" } }, "sha512-aSuM6q6/Gs2FGUqytlHDjKZpSst2xKaT0vMXUQFWUctECNIxvwy6/hTDDInukMuI9mrQdjnO781ZJJgghI7RNw=="],
+
+    "applesauce-relay": ["applesauce-relay@5.2.0", "", { "dependencies": { "@noble/hashes": "^1.7.1", "applesauce-core": "^5.2.0", "nanoid": "^5.0.9", "nostr-tools": "~2.19", "rxjs": "^7.8.1" } }, "sha512-ty8PzHenocGdTr3x3It8Ql0rMD9rxB6VGCzGRfL5QF6epdstv2YHKuTyr8QdPBvf7yxfc7oZcMi6djSwNxXqkQ=="],
 
     "arg": ["arg@5.0.2", "", {}, "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="],
 
@@ -904,6 +921,8 @@
 
     "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
 
+    "hash-sum": ["hash-sum@2.0.0", "", {}, "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg=="],
+
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
     "hast-util-from-html": ["hast-util-from-html@2.0.3", "", { "dependencies": { "@types/hast": "^3.0.0", "devlop": "^1.1.0", "hast-util-from-parse5": "^8.0.0", "parse5": "^7.0.0", "vfile": "^6.0.0", "vfile-message": "^4.0.0" } }, "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw=="],
@@ -1242,7 +1261,7 @@
 
     "muggle-string": ["muggle-string@0.4.1", "", {}, "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ=="],
 
-    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+    "nanoid": ["nanoid@5.1.9", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw=="],
 
     "napi-postinstall": ["napi-postinstall@0.3.4", "", { "bin": { "napi-postinstall": "lib/cli.js" } }, "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ=="],
 
@@ -1261,6 +1280,10 @@
     "node-releases": ["node-releases@2.0.26", "", {}, "sha512-S2M9YimhSjBSvYnlr5/+umAnPHE++ODwt5e2Ij6FoX45HA/s4vHdkDx1eax2pAPeAOqu4s9b7ppahsyEFdVqQA=="],
 
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
+
+    "nostr-tools": ["nostr-tools@2.19.4", "", { "dependencies": { "@noble/ciphers": "^0.5.1", "@noble/curves": "1.2.0", "@noble/hashes": "1.3.1", "@scure/base": "1.1.1", "@scure/bip32": "1.3.1", "@scure/bip39": "1.2.1", "nostr-wasm": "0.1.0" }, "peerDependencies": { "typescript": ">=5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-qVLfoTpZegNYRJo5j+Oi6RPu0AwLP6jcvzcB3ySMnIT5DrAGNXfs5HNBspB/2HiGfH3GY+v6yXkTtcKSBQZwSg=="],
+
+    "nostr-wasm": ["nostr-wasm@0.1.0", "", {}, "sha512-78BTryCLcLYv96ONU8Ws3Q1JzjlAt+43pWQhIl86xZmWeegYCNLPml7yQ+gG3vR6V5h4XGj+TxO+SS5dsThQIA=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
@@ -1441,6 +1464,8 @@
     "rollup": ["rollup@4.52.5", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.52.5", "@rollup/rollup-android-arm64": "4.52.5", "@rollup/rollup-darwin-arm64": "4.52.5", "@rollup/rollup-darwin-x64": "4.52.5", "@rollup/rollup-freebsd-arm64": "4.52.5", "@rollup/rollup-freebsd-x64": "4.52.5", "@rollup/rollup-linux-arm-gnueabihf": "4.52.5", "@rollup/rollup-linux-arm-musleabihf": "4.52.5", "@rollup/rollup-linux-arm64-gnu": "4.52.5", "@rollup/rollup-linux-arm64-musl": "4.52.5", "@rollup/rollup-linux-loong64-gnu": "4.52.5", "@rollup/rollup-linux-ppc64-gnu": "4.52.5", "@rollup/rollup-linux-riscv64-gnu": "4.52.5", "@rollup/rollup-linux-riscv64-musl": "4.52.5", "@rollup/rollup-linux-s390x-gnu": "4.52.5", "@rollup/rollup-linux-x64-gnu": "4.52.5", "@rollup/rollup-linux-x64-musl": "4.52.5", "@rollup/rollup-openharmony-arm64": "4.52.5", "@rollup/rollup-win32-arm64-msvc": "4.52.5", "@rollup/rollup-win32-ia32-msvc": "4.52.5", "@rollup/rollup-win32-x64-gnu": "4.52.5", "@rollup/rollup-win32-x64-msvc": "4.52.5", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-3GuObel8h7Kqdjt0gxkEzaifHTqLVW56Y/bjN7PSQtkKr0w3V/QYSdt6QWYtd7A1xUtYQigtdUfgj1RvWVtorw=="],
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
+
+    "rxjs": ["rxjs@7.8.2", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA=="],
 
     "s.color": ["s.color@0.0.15", "", {}, "sha512-AUNrbEUHeKY8XsYr/DYpl+qk5+aM+DChopnWOPEzn8YKzOhv4l2zH6LzZms3tOZP3wwdOyc0RmTciyi46HLIuA=="],
 
@@ -1742,7 +1767,15 @@
 
     "@eslint/eslintrc/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
+    "@noble/curves/@noble/hashes": ["@noble/hashes@1.3.2", "", {}, "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="],
+
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+
+    "@scure/bip32/@noble/curves": ["@noble/curves@1.1.0", "", { "dependencies": { "@noble/hashes": "1.3.1" } }, "sha512-091oBExgENk/kGj3AZmtBDMpxQPDtxQABR2B9lb1JbVTs6ytdzZNwvhxQ4MWasRNEzlbEH8jCWFCwhF/Obj5AA=="],
+
+    "@scure/bip32/@noble/hashes": ["@noble/hashes@1.3.1", "", {}, "sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA=="],
+
+    "@scure/bip39/@noble/hashes": ["@noble/hashes@1.3.2", "", {}, "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.6.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-zq/ay+9fNIJJtJiZxdTnXS20PllcYMX3OE23ESc4HK/bdYu3cOWYVhsOhVnXALfU/uqJIxn5NBPd9z4v+SfoSg=="],
 
@@ -1822,9 +1855,13 @@
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
+    "nostr-tools/@noble/hashes": ["@noble/hashes@1.3.1", "", {}, "sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA=="],
+
     "p-locate/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+
+    "postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -134,7 +134,7 @@
 
     "@emmetio/css-abbreviation": ["@emmetio/css-abbreviation@2.1.8", "", { "dependencies": { "@emmetio/scanner": "^1.0.4" } }, "sha512-s9yjhJ6saOO/uk1V74eifykk2CBYi01STTK3WlXWGOepyKa23ymJ053+DNQjpFcy1ingpaO7AxCcwLvHFY9tuw=="],
 
-    "@emmetio/css-parser": ["@emmetio/css-parser@github:ramya-rao-a/css-parser#370c480", { "dependencies": { "@emmetio/stream-reader": "^2.2.0", "@emmetio/stream-reader-utils": "^0.1.0" } }, "ramya-rao-a-css-parser-370c480"],
+    "@emmetio/css-parser": ["@emmetio/css-parser@github:ramya-rao-a/css-parser#370c480", { "dependencies": { "@emmetio/stream-reader": "^2.2.0", "@emmetio/stream-reader-utils": "^0.1.0" } }, "ramya-rao-a-css-parser-370c480", "sha512-dYkDEiBYU6kAT6FMOUEZM5QsIOvOJ4zVC5IYTRDizfhEuAptmf+tXSaGmJSRy4HEgqITT9Af7FZxbskdg6E2xg=="],
 
     "@emmetio/html-matcher": ["@emmetio/html-matcher@1.3.0", "", { "dependencies": { "@emmetio/scanner": "^1.0.0" } }, "sha512-NTbsvppE5eVyBMuyGfVu2CRrLvo7J4YHb6t9sBFLyY03WYhXET37qA4zOYUjBWFCRHO7pS1B9khERtY0f5JXPQ=="],
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@fontsource/im-fell-double-pica": "^5.2.6",
     "@fortawesome/fontawesome-free": "^7.0.0",
     "@justinribeiro/lite-youtube": "^1.8.2",
+    "applesauce-relay": "^5.2.0",
     "astro": "5.7.8",
     "astro-auto-import": "^0.4.4",
     "astro-fathom": "^2.0.0",

--- a/src/layouts/components/CohortDropdown.astro
+++ b/src/layouts/components/CohortDropdown.astro
@@ -1,0 +1,50 @@
+---
+interface Props {
+  /** Current cohort (e.g. "SEC-01") if on a cohort-specific page; undefined on /projects index. */
+  current?: string;
+}
+
+const { current } = Astro.props;
+
+const cohorts = [
+  "SEC-00",
+  "SEC-01",
+  "SEC-02",
+  "SEC-03",
+  "SEC-04",
+  "SEC-05",
+  "SEC-06",
+  "SEC-07",
+];
+---
+
+<div class="w-full bg-black pt-12 pb-4 flex justify-center">
+  <div class="flex items-center gap-3">
+    <label for="cohort-select" class="text-white text-sm tracking-wider uppercase">
+      Cohort:
+    </label>
+    <select
+      id="cohort-select"
+      class="bg-black text-white border border-white px-4 py-2 text-base focus:outline-none focus:ring-2 focus:ring-white cursor-pointer"
+    >
+      <option value="">Highlights</option>
+      {
+        cohorts.map((c) => (
+          <option value={c.toLowerCase().replace("-", "")} selected={current === c}>
+            {c}
+          </option>
+        ))
+      }
+    </select>
+  </div>
+</div>
+
+<script>
+  const sel = document.getElementById("cohort-select") as HTMLSelectElement | null;
+  if (sel) {
+    sel.addEventListener("change", (e) => {
+      const value = (e.target as HTMLSelectElement).value;
+      window.location.href = value ? `/projects/${value}` : "/projects";
+    });
+  }
+</script>

--- a/src/layouts/components/CohortDropdown.astro
+++ b/src/layouts/components/CohortDropdown.astro
@@ -18,25 +18,20 @@ const cohorts = [
 ];
 ---
 
-<div class="w-full bg-black pt-12 pb-4 flex justify-center">
-  <div class="flex items-center gap-3">
-    <label for="cohort-select" class="text-white text-sm tracking-wider uppercase">
-      Cohort:
-    </label>
-    <select
-      id="cohort-select"
-      class="bg-black text-white border border-white px-4 py-2 text-base focus:outline-none focus:ring-2 focus:ring-white cursor-pointer"
-    >
-      <option value="">Highlights</option>
-      {
-        cohorts.map((c) => (
-          <option value={c.toLowerCase().replace("-", "")} selected={current === c}>
-            {c}
-          </option>
-        ))
-      }
-    </select>
-  </div>
+<div style="display: flex; justify-content: center; padding-top: 1rem; padding-bottom: 0.5rem;">
+  <select
+    id="cohort-select"
+    style="background: transparent; color: #fff; border: 1px solid #52525b; padding: 0.5rem 2rem 0.5rem 1rem; font-size: 1rem; cursor: pointer; appearance: auto;"
+  >
+    <option value="" style="background: #000;">Highlights</option>
+    {
+      cohorts.map((c) => (
+        <option value={c.toLowerCase().replace("-", "")} selected={current === c} style="background: #000;">
+          {c}
+        </option>
+      ))
+    }
+  </select>
 </div>
 
 <script>

--- a/src/layouts/components/DemoGallery.tsx
+++ b/src/layouts/components/DemoGallery.tsx
@@ -1,0 +1,373 @@
+import { useEffect, useState } from "react";
+import {
+  nostrService,
+  type NostrProfile,
+} from "../helpers/nostr/NostrService";
+import type { NostrEvent } from "nostr-tools";
+
+const BRAND_RED = "#ED3238";
+
+function VideoModal({
+  src,
+  onClose,
+}: {
+  src: string;
+  onClose: () => void;
+}) {
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 9999,
+        background: "rgba(0, 0, 0, 0.9)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        cursor: "pointer",
+      }}
+    >
+      {/* Phone-sized container */}
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          position: "relative",
+          width: "min(375px, 90vw)",
+          maxHeight: "85vh",
+          borderRadius: "1.5rem",
+          overflow: "hidden",
+          background: "#000",
+          border: "3px solid #27272a",
+          cursor: "default",
+        }}
+      >
+        <video
+          src={src}
+          controls
+          autoPlay
+          playsInline
+          style={{
+            display: "block",
+            width: "100%",
+            maxHeight: "85vh",
+            objectFit: "contain",
+            background: "#000",
+          }}
+        />
+        <button
+          onClick={onClose}
+          style={{
+            position: "absolute",
+            top: 8,
+            right: 8,
+            width: 32,
+            height: 32,
+            borderRadius: "50%",
+            background: "rgba(0,0,0,0.7)",
+            border: "1px solid #555",
+            color: "#fff",
+            fontSize: 18,
+            cursor: "pointer",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            lineHeight: 1,
+          }}
+        >
+          ✕
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function formatRelativeTime(unixSeconds: number): string {
+  const diffSec = Math.floor(Date.now() / 1000) - unixSeconds;
+  const day = 24 * 60 * 60;
+  if (diffSec < 60) return "just now";
+  if (diffSec < 3600) return `${Math.floor(diffSec / 60)}m ago`;
+  if (diffSec < day) return `${Math.floor(diffSec / 3600)}h ago`;
+  return `${Math.floor(diffSec / day)}d ago`;
+}
+
+interface DemoCardProps {
+  event: NostrEvent;
+  profile?: NostrProfile;
+  onExpand?: (videoUrl: string) => void;
+}
+
+function DemoCard({ event, profile, onExpand }: DemoCardProps) {
+  const title = nostrService.extractTitle(event);
+  const videoUrl = nostrService.extractVideoUrl(event);
+  const imageUrl = nostrService.extractImage(event);
+  const authorName =
+    profile?.display_name ||
+    profile?.displayName ||
+    profile?.name ||
+    `${event.pubkey.slice(0, 8)}…${event.pubkey.slice(-4)}`;
+  const avatarSrc = profile?.picture || profile?.image;
+
+  return (
+    <article
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        overflow: "hidden",
+        borderRadius: "1rem",
+        border: "1px solid #27272a",
+        background: "#09090b",
+        padding: "1.5rem",
+      }}
+    >
+      {/* Header: avatar + author + time */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "0.75rem",
+          marginBottom: "1rem",
+        }}
+      >
+        {avatarSrc ? (
+          <img
+            src={avatarSrc}
+            alt={authorName}
+            style={{
+              width: 40,
+              height: 40,
+              borderRadius: "50%",
+              objectFit: "cover",
+              flexShrink: 0,
+              background: "#fff",
+            }}
+          />
+        ) : (
+          <div
+            style={{
+              width: 40,
+              height: 40,
+              borderRadius: "50%",
+              background: "#27272a",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              color: "#71717a",
+              fontSize: 12,
+              fontWeight: 700,
+              flexShrink: 0,
+            }}
+          >
+            {authorName.charAt(0).toUpperCase()}
+          </div>
+        )}
+        <div
+          style={{ display: "flex", flexDirection: "column", lineHeight: 1.2 }}
+        >
+          <span
+            style={{ fontSize: 14, fontWeight: 500, color: "#f4f4f5" }}
+          >
+            {authorName}
+          </span>
+          <span style={{ fontSize: 12, color: "#a1a1aa" }}>
+            {formatRelativeTime(event.created_at)}
+          </span>
+        </div>
+      </div>
+
+      {/* Video thumbnail — compact 16:9 preview. Clicking the expand
+          button opens a phone-sized modal instead of native fullscreen. */}
+      {videoUrl && (
+        <div
+          style={{ position: "relative", marginBottom: "1rem" }}
+        >
+          <video
+            src={videoUrl}
+            controls
+            playsInline
+            controlsList="nofullscreen"
+            className="demo-video-thumb"
+            style={{
+              width: "100%",
+              aspectRatio: "16 / 9",
+              objectFit: "cover",
+              background: "#000",
+              borderRadius: "0.5rem",
+              display: "block",
+            }}
+          />
+          <button
+            onClick={() => onExpand?.(videoUrl)}
+            style={{
+              position: "absolute",
+              top: 8,
+              right: 8,
+              width: 32,
+              height: 32,
+              borderRadius: 6,
+              background: "rgba(0,0,0,0.7)",
+              border: "1px solid #555",
+              color: "#fff",
+              fontSize: 14,
+              cursor: "pointer",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+            title="Watch at phone size"
+          >
+            ⛶
+          </button>
+        </div>
+      )}
+      {!videoUrl && imageUrl && (
+        <img
+          src={imageUrl}
+          alt={title}
+          style={{
+            width: "100%",
+            aspectRatio: "16 / 9",
+            objectFit: "cover",
+            borderRadius: "0.5rem",
+            marginBottom: "1rem",
+          }}
+        />
+      )}
+
+      {/* Title */}
+      <h3
+        style={{
+          fontSize: "1.125rem",
+          fontWeight: 600,
+          lineHeight: 1.25,
+          color: "#fff",
+          margin: 0,
+          flex: 1,
+        }}
+      >
+        {title}
+      </h3>
+
+      {/* Footer link */}
+      <div
+        style={{
+          marginTop: "auto",
+          paddingTop: "0.5rem",
+          borderTop: "1px solid #27272a",
+        }}
+      >
+        <a
+          href={`https://njump.me/${event.id}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{
+            fontSize: 14,
+            fontWeight: 500,
+            color: BRAND_RED,
+            textDecoration: "none",
+          }}
+        >
+          View on Nostr →
+        </a>
+      </div>
+    </article>
+  );
+}
+
+export default function DemoGallery() {
+  const [demos, setDemos] = useState<NostrEvent[]>([]);
+  const [profiles, setProfiles] = useState<Map<string, NostrProfile>>(new Map());
+  const [loading, setLoading] = useState(true);
+  const [allowlistSource, setAllowlistSource] = useState<
+    "nostr" | "fallback"
+  >("fallback");
+  const [expandedVideo, setExpandedVideo] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    nostrService.fetchPageData().then((data) => {
+      if (cancelled) return;
+      setDemos(data.demos);
+      setProfiles(data.profiles);
+      setAllowlistSource(data.allowlistSource);
+      setLoading(false);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (loading) {
+    return (
+      <div
+        style={{
+          textAlign: "center",
+          padding: "3rem",
+          color: "#a1a1aa",
+        }}
+      >
+        Loading demos from Nostr...
+      </div>
+    );
+  }
+
+  if (demos.length === 0) {
+    return (
+      <div
+        style={{
+          borderRadius: "1rem",
+          border: "1px dashed #3f3f46",
+          background: "#09090b",
+          padding: "3rem",
+          textAlign: "center",
+        }}
+      >
+        <p style={{ fontSize: 16, fontWeight: 500, color: "#e4e4e7" }}>
+          No demos posted yet for this cohort.
+        </p>
+        <p
+          style={{ marginTop: "0.5rem", fontSize: 14, color: "#a1a1aa" }}
+        >
+          Cohort participants: post a kind:1 note tagged{" "}
+          <code style={{ color: BRAND_RED }}>#demoday</code> from your npub
+          to appear here.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div
+        style={{
+          textAlign: "center",
+          fontSize: 12,
+          color: "#a1a1aa",
+          marginBottom: "1.5rem",
+        }}
+      >
+        {demos.length} live demo{demos.length === 1 ? "" : "s"} pulled from
+        Nostr ·{" "}
+        {allowlistSource === "nostr"
+          ? "curator-published allowlist"
+          : "hardcoded cohort fallback"}
+      </div>
+      {expandedVideo && (
+        <VideoModal
+          src={expandedVideo}
+          onClose={() => setExpandedVideo(null)}
+        />
+      )}
+      <div className="cohort-masonry">
+        {demos.map((event) => (
+          <DemoCard
+            key={event.id}
+            event={event}
+            profile={profiles.get(event.pubkey)}
+            onExpand={setExpandedVideo}
+          />
+        ))}
+      </div>
+    </>
+  );
+}

--- a/src/layouts/components/ProjectCard.astro
+++ b/src/layouts/components/ProjectCard.astro
@@ -1,0 +1,97 @@
+---
+interface ExtraLink {
+  link: string;
+  linkText: string;
+}
+
+interface Project {
+  name: string;
+  description: string;
+  cohort: string;
+  link: string;
+  linkText: string;
+  logo?: string;
+  highlight?: boolean;
+  extraLinks?: ExtraLink[];
+}
+
+interface Props {
+  project: Project;
+}
+
+const { project } = Astro.props;
+---
+
+<article
+  class="flex flex-col overflow-hidden rounded-2xl border border-zinc-800 bg-zinc-950 p-6 transition hover:border-zinc-700"
+>
+  {/* Header row: logo + cohort label */}
+  <div class="flex items-center gap-3 mb-4">
+    {
+      project.logo ? (
+        <img
+          src={project.logo}
+          alt={`${project.name} logo`}
+          class="rounded-full object-cover bg-white p-1 flex-shrink-0"
+          style="width: 40px; height: 40px;"
+        />
+      ) : (
+        <div
+          class="rounded-full bg-zinc-800 flex items-center justify-center text-zinc-500 text-xs font-bold flex-shrink-0"
+          style="width: 40px; height: 40px;"
+        >
+          {project.name.charAt(0).toUpperCase()}
+        </div>
+      )
+    }
+    <div class="flex flex-col leading-tight">
+      <span class="text-sm font-medium text-zinc-100">{project.cohort}</span>
+      {
+        project.highlight && (
+          <span
+            class="uppercase tracking-wider"
+            style="font-size: 10px; color: #ED3238;"
+          >
+            Highlight
+          </span>
+        )
+      }
+    </div>
+  </div>
+
+  {/* Title */}
+  <h3 class="text-lg font-semibold leading-tight text-white mb-3">
+    {project.name}
+  </h3>
+
+  {/* Description */}
+  <p class="text-sm leading-relaxed text-zinc-300 mb-4 flex-1">
+    {project.description}
+  </p>
+
+  {/* Links */}
+  <div class="flex flex-col gap-1.5 mt-auto pt-2 border-t border-zinc-800">
+    <a
+      href={project.link}
+      target="_blank"
+      rel="noopener noreferrer"
+      class="text-sm font-medium hover:underline project-link"
+      style="color: #ED3238;"
+    >
+      {project.linkText} →
+    </a>
+    {
+      project.extraLinks &&
+        project.extraLinks.map((extra) => (
+          <a
+            href={extra.link}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-xs text-zinc-500 hover:text-zinc-300 hover:underline"
+          >
+            {extra.linkText} →
+          </a>
+        ))
+    }
+  </div>
+</article>

--- a/src/layouts/components/ProjectShowcase.astro
+++ b/src/layouts/components/ProjectShowcase.astro
@@ -36,7 +36,8 @@ const {
   darkTheme = false,
   showTitle = false,
   groupByCohort = true,
-  showHighlights = false
+  showHighlights = false,
+  showCTA = true
 } = Astro.props;
 
 // Group projects by cohort
@@ -249,19 +250,21 @@ const cohortHeaderClasses = darkTheme
         ))}
 
         {/* CTA Section */}
-        <div class="mt-16 text-center">
-          <h2 class={cohortHeaderClasses} style="font-family: 'IM Fell Double Pica', Times, serif;">
-            SEC-07
-          </h2>
-          <div class="py-12">
-            <p class={`text-xl mb-8 ${darkTheme ? 'text-gray-300' : 'text-text'}`}>
-              Your Project Here
-            </p>
-            <p class={`text-lg mb-8 ${darkTheme ? 'text-gray-300' : 'text-text'}`}>
-              Join the next cohort and build the future you want to see.
-            </p>
+        {showCTA && (
+          <div class="mt-16 text-center">
+            <h2 class={cohortHeaderClasses} style="font-family: 'IM Fell Double Pica', Times, serif;">
+              SEC-07
+            </h2>
+            <div class="py-12">
+              <p class={`text-xl mb-8 ${darkTheme ? 'text-gray-300' : 'text-text'}`}>
+                Your Project Here
+              </p>
+              <p class={`text-lg mb-8 ${darkTheme ? 'text-gray-300' : 'text-text'}`}>
+                Join the next cohort and build the future you want to see.
+              </p>
+            </div>
           </div>
-        </div>
+        )}
       </>
     ) : (
       <div class="overflow-x-auto mb-8">

--- a/src/layouts/helpers/nostr/NostrService.ts
+++ b/src/layouts/helpers/nostr/NostrService.ts
@@ -1,0 +1,164 @@
+import { RelayPool } from "applesauce-relay";
+import { completeOnEose } from "applesauce-relay/operators";
+import { lastValueFrom, toArray } from "rxjs";
+import type { Filter, NostrEvent } from "nostr-tools";
+import {
+  HASHTAGS,
+  ALLOWED_PUBKEYS,
+  CURATOR_PUBKEYS,
+  COHORT_D_TAGS,
+  COHORT_START_TIMESTAMP,
+  COHORT_END_TIMESTAMP,
+  DEFAULT_RELAYS,
+} from "./config";
+
+export interface NostrProfile {
+  name?: string;
+  displayName?: string;
+  display_name?: string;
+  about?: string;
+  picture?: string;
+  image?: string;
+  banner?: string;
+  nip05?: string;
+  lud16?: string;
+}
+
+export interface PageData {
+  allowlistPubkeys: string[];
+  allowlistSource: "nostr" | "fallback";
+  cohortListCount: number;
+  demos: NostrEvent[];
+  profiles: Map<string, NostrProfile>;
+}
+
+export class NostrService {
+  private pool: RelayPool;
+
+  constructor() {
+    // Browser has native WebSocket — no need to inject `ws` like the SSR
+    // version does. Lower EOSE timeout for snappy in-browser fetches.
+    this.pool = new RelayPool({ eoseTimeout: 1200 });
+  }
+
+  private async fetchEvents(
+    filters: Filter | Filter[],
+  ): Promise<NostrEvent[]> {
+    try {
+      return await lastValueFrom(
+        this.pool
+          .req(DEFAULT_RELAYS, filters)
+          .pipe(completeOnEose(), toArray()),
+      );
+    } catch (err) {
+      console.error("[NostrService] fetchEvents threw:", err);
+      return [];
+    }
+  }
+
+  /**
+   * Single-round-trip fetch: cohort lists + demo events + profiles in one REQ.
+   * Relays process all three filters in parallel and emit one EOSE.
+   */
+  async fetchPageData(): Promise<PageData> {
+    const filters: Filter[] = [
+      {
+        kinds: [30000],
+        authors: CURATOR_PUBKEYS,
+        "#d": COHORT_D_TAGS,
+      },
+      {
+        kinds: [1],
+        authors: ALLOWED_PUBKEYS,
+        "#t": HASHTAGS,
+        since: COHORT_START_TIMESTAMP,
+        until: COHORT_END_TIMESTAMP,
+        limit: 200,
+      },
+      {
+        kinds: [0],
+        authors: ALLOWED_PUBKEYS,
+      },
+    ];
+
+    const events = await this.fetchEvents(filters);
+
+    const cohortListEvents = events.filter((e) => e.kind === 30000);
+    const demoEventsRaw = events.filter((e) => e.kind === 1);
+    const profileEvents = events.filter((e) => e.kind === 0);
+
+    // Resolve allowlist (cohort list union, fallback to hardcoded)
+    let allowlistPubkeys: string[] = ALLOWED_PUBKEYS;
+    let allowlistSource: "nostr" | "fallback" = "fallback";
+    if (cohortListEvents.length > 0) {
+      const set = new Set<string>();
+      cohortListEvents.forEach((e) => {
+        e.tags
+          .filter((t) => t[0] === "p" && t[1])
+          .forEach((t) => set.add(t[1]));
+      });
+      if (set.size > 0) {
+        allowlistPubkeys = Array.from(set);
+        allowlistSource = "nostr";
+      }
+    }
+
+    const allowlistSet = new Set(allowlistPubkeys);
+    const demoMap = new Map<string, NostrEvent>();
+    for (const e of demoEventsRaw) {
+      if (allowlistSet.has(e.pubkey) && !demoMap.has(e.id))
+        demoMap.set(e.id, e);
+    }
+    const demos = Array.from(demoMap.values()).sort(
+      (a, b) => b.created_at - a.created_at,
+    );
+
+    const latestProfile = new Map<string, NostrEvent>();
+    for (const e of profileEvents) {
+      const prev = latestProfile.get(e.pubkey);
+      if (!prev || e.created_at > prev.created_at)
+        latestProfile.set(e.pubkey, e);
+    }
+    const profiles = new Map<string, NostrProfile>();
+    for (const [pubkey, event] of latestProfile) {
+      try {
+        profiles.set(pubkey, JSON.parse(event.content) as NostrProfile);
+      } catch {
+        // ignore malformed profile JSON
+      }
+    }
+
+    return {
+      allowlistPubkeys,
+      allowlistSource,
+      cohortListCount: cohortListEvents.length,
+      demos,
+      profiles,
+    };
+  }
+
+  extractTitle(event: NostrEvent): string {
+    const titleTag = event.tags.find((tag) => tag[0] === "title");
+    if (titleTag) return titleTag[1];
+    const firstLine = event.content.split("\n")[0].trim();
+    return firstLine.length > 140
+      ? `${firstLine.substring(0, 137)}...`
+      : firstLine || "(untitled demo)";
+  }
+
+  extractImage(event: NostrEvent): string | undefined {
+    const imageTag = event.tags.find((tag) => tag[0] === "image");
+    if (imageTag) return imageTag[1];
+    const m = event.content.match(
+      /(https?:\/\/[^\s]+\.(?:jpg|jpeg|png|gif|webp))/i,
+    );
+    return m?.[0];
+  }
+
+  extractVideoUrl(event: NostrEvent): string | undefined {
+    const m = event.content.match(/(https?:\/\/[^\s]+\.(?:mp4|webm|mov))/i);
+    return m?.[0];
+  }
+}
+
+export const nostrService = new NostrService();

--- a/src/layouts/helpers/nostr/config.ts
+++ b/src/layouts/helpers/nostr/config.ts
@@ -1,0 +1,76 @@
+// Configuration for the live Nostr demo gallery embedded on the active
+// cohort's project page. Update these when a new cohort begins.
+
+// Hashtag participants tag their demo posts with on Nostr.
+export const HASHTAGS = ["demoday"];
+
+// Active cohort window. Posts outside this range are filtered out at the
+// relay level. Update when a new cohort begins.
+const COHORT_START_ISO = "2026-03-30T00:00:00Z";
+const COHORT_END_ISO = "2026-04-20T23:59:59Z";
+
+export const COHORT_START_TIMESTAMP = Math.floor(
+  new Date(COHORT_START_ISO).getTime() / 1000,
+);
+export const COHORT_END_TIMESTAMP = Math.floor(
+  new Date(COHORT_END_ISO).getTime() / 1000,
+);
+
+// Trusted curators allowed to publish kind:30000 cohort lists. When a curator
+// publishes one for the active cohort, the page automatically uses it as
+// the allowlist instead of the hardcoded fallback below.
+export const CURATOR_PUBKEYS = [
+  // dergigi
+  "6e468422dfb74a5738702a8823b9b28168abab8655faacb6853cd0ee15deee93",
+  // yo
+  "d60bdad03468f5f8c85b1b10db977e310a5aafab33750dfadb37488b02bfc8d7",
+];
+
+// d-tags we look for on kind:30000 events (e.g. "sec07" for cohort 7).
+export const COHORT_D_TAGS = Array.from(
+  { length: 50 },
+  (_, i) => `sec${String(i + 1).padStart(2, "0")}`,
+);
+
+// Hardcoded fallback allowlist — used when no curator has published a cohort
+// list yet. These are SEC-07 cohort participant pubkeys (decoded from npubs).
+export const ALLOWED_PUBKEYS = [
+  "dc6c293fae6009e2a4880ada9cac807fb63fed7317ed5ff3e59b0209e8d30dae", // Maroon
+  "d60bdad03468f5f8c85b1b10db977e310a5aafab33750dfadb37488b02bfc8d7", // yo
+  "6e468422dfb74a5738702a8823b9b28168abab8655faacb6853cd0ee15deee93", // Gigi
+  "c3e23eb5e376ed584973a6e0efdab8e3d911de6ded858110a12482ca3db6539a", // c03rad0r
+  "bbb5dda0e15567979f0543407bdc2033d6f0bbb30f72512a981cfdb2f09e2747", // Arjen
+  "f53b9d91a8cd177fb4a1cf081a1b6d58759a381ef120a7c5a18c0e70cae80983", // Thomas
+  "a136247d8caf7e30bf403d32006faeca0c9d1cec7a16075e4142c2fed6cade60", // Shadrach
+  "40b9c85fffeafc1cadf8c30a4e5c88660ff6e4971a0dc723d5ab674b5e61b451", // Gzuuus
+  "1634b87b5fcfd4a6c4ff2f2de17450ccce46f9abe0b02a71876c596ec165bfed", // k0
+  "1f830dd875130b134fbf3f27a69eecd8613a499748a71b5a271a719febae14ed", // Dimi
+  "d02a3b54e6433fc7c2608e99ef9b4aed9039644446da9822d20b5b9890964f2f", // oleksky
+  "2bbace553efebf58dd55912169f92c1123eb6121d7ba092f6c50104afc31acef", // Johnathan Corgan
+  "11b9a89404dbf3034e7e1886ba9dc4c6d376f239a118271bd2ec567a889850ce", // Justin Moon
+  "4ad6fa2d16e2a9b576c863b4cf7404a70d4dc320c0c447d10ad6ff58993eacc8", // redshift
+  "12ee03d11684a125dd87be879c28190415be3f3b1eca6b4ed743bd74ffd880e6", // SatsAndSports
+  "056f33245ca4cc4fa3c1d6e557dd8eae714889f3c3423cbd6fbf09f3c0e200d2", // Alex Xie
+  "b158557dddf53d5b98e7fb7597a294f67c7cb6accdcc9aea9f6a5ab50fae01ee", // Chester Arinc
+  "9ec7a778167afb1d30c4833de9322da0c08ba71a69e1911d5578d3144bb56437", // balas
+  "4523be58d395b1b196a9b8c82b038b6895cb02b683d0c253a955068dba1facd0", // Sirius
+  "6eef2e68c399c8f2efbf70d831c2b618d7a84bdfd21734a81e6d7d3d817f6850", // lauri
+];
+
+// Curated set of free, generally reliable relays. Different Nostr clients
+// publish to different relays by default, so a wide net catches posts
+// regardless of which client a participant uses.
+export const DEFAULT_RELAYS = [
+  "wss://relay.nostr.band",
+  "wss://relay.damus.io",
+  "wss://nos.lol",
+  "wss://relay.primal.net",
+  "wss://relay.snort.social",
+  "wss://offchain.pub",
+  "wss://nostr.mom",
+  "wss://purplerelay.com",
+  "wss://relay.nostrify.io",
+  "wss://nostr.bitcoiner.social",
+  "wss://nostr.fmt.wiz.biz",
+  "wss://relay.nostr.bg",
+];

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -1,21 +1,116 @@
 ---
 import Base from "@/layouts/Base.astro";
-import ProjectShowcase from "@/components/ProjectShowcase.astro";
+import CohortDropdown from "@/components/CohortDropdown.astro";
+import ProjectCard from "@/components/ProjectCard.astro";
 import showcaseProjects from "@/data/showcaseProjects.js";
 
+interface ExtraLink {
+  link: string;
+  linkText: string;
+}
+
+interface Project {
+  name: string;
+  description: string;
+  cohort: string;
+  link: string;
+  linkText: string;
+  logo?: string;
+  highlight?: boolean;
+  extraLinks?: ExtraLink[];
+}
+
+const highlights = (showcaseProjects as Project[]).filter((p) => p.highlight);
 ---
 
 <Base
-  title="Demo Day Projects"
-  meta_title="Demo Day Projects"
-  description="Explore projects built by Sovereign Engineering Cohort participants during their Demo Days"
+  title="Highlights — Demo Day Projects"
+  meta_title="Highlights — Demo Day Projects"
+  description="Featured projects from Sovereign Engineering Cohort participants — the standout demos selected from across all cohorts."
 >
-  <ProjectShowcase
-    projects={showcaseProjects}
-    darkTheme={true}
-    showTitle={true}
-    showHighlights={true}
-  />
+  <CohortDropdown />
 
-  <!-- No Next link here; flow handled from /podcast -->
+  <section class="cohort-section">
+    <div class="cohort-container">
+      <header class="cohort-header">
+        <h1
+          class="cohort-title"
+          style="font-family: 'IM Fell Double Pica', Times, serif;"
+        >
+          Highlights
+        </h1>
+        <p class="cohort-subtitle">
+          Standout projects featured from across all Sovereign Engineering cohorts.
+        </p>
+      </header>
+
+      <div class="cohort-masonry">
+        {highlights.map((project) => <ProjectCard project={project} />)}
+      </div>
+    </div>
+  </section>
 </Base>
+
+<style>
+  .cohort-section {
+    width: 100%;
+    background: #000;
+    color: #fff;
+    padding-top: 4rem;
+    padding-bottom: 4rem;
+  }
+  .cohort-container {
+    max-width: 1280px;
+    margin-left: auto;
+    margin-right: auto;
+    padding-left: 3rem;
+    padding-right: 3rem;
+  }
+  @media (min-width: 1024px) {
+    .cohort-container {
+      padding-left: 5rem;
+      padding-right: 5rem;
+    }
+  }
+  .cohort-header {
+    margin-bottom: 3rem;
+    text-align: center;
+  }
+  .cohort-title {
+    font-size: 2.5rem;
+    font-weight: 400;
+    color: #fff;
+  }
+  .cohort-subtitle {
+    margin-top: 1rem;
+    font-size: 1rem;
+    color: rgb(161, 161, 170);
+    max-width: 42rem;
+    margin-left: auto;
+    margin-right: auto;
+  }
+  .cohort-masonry {
+    column-count: 1;
+    column-gap: 4rem;
+  }
+  .cohort-masonry > * {
+    break-inside: avoid;
+    -webkit-column-break-inside: avoid;
+    page-break-inside: avoid;
+    display: inline-block;
+    width: 100%;
+    margin-bottom: 3.5rem;
+  }
+  @media (min-width: 640px) {
+    .cohort-masonry {
+      column-count: 2;
+      column-gap: 5rem;
+    }
+  }
+  @media (min-width: 1024px) {
+    .cohort-masonry {
+      column-count: 3;
+      column-gap: 6rem;
+    }
+  }
+</style>

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -28,8 +28,6 @@ const highlights = (showcaseProjects as Project[]).filter((p) => p.highlight);
   meta_title="Highlights — Demo Day Projects"
   description="Featured projects from Sovereign Engineering Cohort participants — the standout demos selected from across all cohorts."
 >
-  <CohortDropdown />
-
   <section class="cohort-section">
     <div class="cohort-container">
       <header class="cohort-header">
@@ -37,8 +35,9 @@ const highlights = (showcaseProjects as Project[]).filter((p) => p.highlight);
           class="cohort-title"
           style="font-family: 'IM Fell Double Pica', Times, serif;"
         >
-          Highlights
+          Demo Day Projects
         </h1>
+        <CohortDropdown />
         <p class="cohort-subtitle">
           Standout projects featured from across all Sovereign Engineering cohorts.
         </p>
@@ -91,7 +90,7 @@ const highlights = (showcaseProjects as Project[]).filter((p) => p.highlight);
   }
   .cohort-masonry {
     column-count: 1;
-    column-gap: 4rem;
+    column-gap: 1.25rem;
   }
   .cohort-masonry > * {
     break-inside: avoid;
@@ -99,18 +98,18 @@ const highlights = (showcaseProjects as Project[]).filter((p) => p.highlight);
     page-break-inside: avoid;
     display: inline-block;
     width: 100%;
-    margin-bottom: 3.5rem;
+    margin-bottom: 1.25rem;
   }
   @media (min-width: 640px) {
     .cohort-masonry {
       column-count: 2;
-      column-gap: 5rem;
+      column-gap: 1.5rem;
     }
   }
   @media (min-width: 1024px) {
     .cohort-masonry {
       column-count: 3;
-      column-gap: 6rem;
+      column-gap: 1.75rem;
     }
   }
 </style>

--- a/src/pages/projects/[cohort].astro
+++ b/src/pages/projects/[cohort].astro
@@ -1,0 +1,156 @@
+---
+import Base from "@/layouts/Base.astro";
+import CohortDropdown from "@/components/CohortDropdown.astro";
+import ProjectCard from "@/components/ProjectCard.astro";
+import showcaseProjects from "@/data/showcaseProjects.js";
+
+interface ExtraLink {
+  link: string;
+  linkText: string;
+}
+
+interface Project {
+  name: string;
+  description: string;
+  cohort: string;
+  link: string;
+  linkText: string;
+  logo?: string;
+  highlight?: boolean;
+  extraLinks?: ExtraLink[];
+}
+
+const COHORTS = [
+  "SEC-00",
+  "SEC-01",
+  "SEC-02",
+  "SEC-03",
+  "SEC-04",
+  "SEC-05",
+  "SEC-06",
+  "SEC-07",
+];
+
+export async function getStaticPaths() {
+  const cohorts = [
+    "SEC-00",
+    "SEC-01",
+    "SEC-02",
+    "SEC-03",
+    "SEC-04",
+    "SEC-05",
+    "SEC-06",
+    "SEC-07",
+  ];
+  return cohorts.map((c) => ({
+    params: { cohort: c.toLowerCase().replace("-", "") },
+    props: { cohortLabel: c },
+  }));
+}
+
+const { cohortLabel } = Astro.props as { cohortLabel: string };
+const filtered = (showcaseProjects as Project[]).filter(
+  (p) => p.cohort === cohortLabel
+);
+const isCurrentCohort = cohortLabel === COHORTS[COHORTS.length - 1];
+---
+
+<Base
+  title={`${cohortLabel} Demo Day Projects`}
+  meta_title={`${cohortLabel} Demo Day Projects`}
+  description={`Projects built by ${cohortLabel} Sovereign Engineering Cohort participants during their Demo Days`}
+>
+  <CohortDropdown current={cohortLabel} />
+
+  <section class="cohort-section">
+    <div class="cohort-container">
+      <header class="mb-12 text-center">
+        <h1
+          class="text-4xl font-normal text-white"
+          style="font-family: 'IM Fell Double Pica', Times, serif;"
+        >
+          {cohortLabel} Demo Day Projects
+        </h1>
+        {
+          filtered.length > 0 && (
+            <p class="mt-4 text-base text-zinc-400">
+              {filtered.length} project{filtered.length === 1 ? "" : "s"} from
+              this cohort
+            </p>
+          )
+        }
+      </header>
+
+      {
+        filtered.length > 0 ? (
+          <div class="cohort-masonry">
+            {filtered.map((project) => (
+              <ProjectCard project={project} />
+            ))}
+          </div>
+        ) : (
+          <div class="rounded-2xl border border-dashed border-zinc-700 bg-zinc-950 p-12 text-center">
+            <p class="text-base font-medium text-zinc-200">
+              {isCurrentCohort
+                ? "This cohort is currently in progress."
+                : "No projects on record for this cohort."}
+            </p>
+            {isCurrentCohort && (
+              <p class="mt-2 text-sm text-zinc-400">
+                Demos will appear here as participants share them.
+              </p>
+            )}
+          </div>
+        )
+      }
+    </div>
+  </section>
+</Base>
+
+<style>
+  .cohort-section {
+    width: 100%;
+    background: #000;
+    color: #fff;
+    padding-top: 4rem;
+    padding-bottom: 4rem;
+  }
+  .cohort-container {
+    max-width: 1280px;
+    margin-left: auto;
+    margin-right: auto;
+    /* Generous horizontal padding so cards never touch the page edges */
+    padding-left: 3rem;
+    padding-right: 3rem;
+  }
+  @media (min-width: 1024px) {
+    .cohort-container {
+      padding-left: 5rem;
+      padding-right: 5rem;
+    }
+  }
+  .cohort-masonry {
+    column-count: 1;
+    column-gap: 4rem;
+  }
+  .cohort-masonry > * {
+    break-inside: avoid;
+    -webkit-column-break-inside: avoid;
+    page-break-inside: avoid;
+    display: inline-block;
+    width: 100%;
+    margin-bottom: 3.5rem;
+  }
+  @media (min-width: 640px) {
+    .cohort-masonry {
+      column-count: 2;
+      column-gap: 5rem;
+    }
+  }
+  @media (min-width: 1024px) {
+    .cohort-masonry {
+      column-count: 3;
+      column-gap: 6rem;
+    }
+  }
+</style>

--- a/src/pages/projects/[cohort].astro
+++ b/src/pages/projects/[cohort].astro
@@ -2,6 +2,7 @@
 import Base from "@/layouts/Base.astro";
 import CohortDropdown from "@/components/CohortDropdown.astro";
 import ProjectCard from "@/components/ProjectCard.astro";
+import DemoGallery from "@/components/DemoGallery.tsx";
 import showcaseProjects from "@/data/showcaseProjects.js";
 
 interface ExtraLink {
@@ -60,17 +61,16 @@ const isCurrentCohort = cohortLabel === COHORTS[COHORTS.length - 1];
   meta_title={`${cohortLabel} Demo Day Projects`}
   description={`Projects built by ${cohortLabel} Sovereign Engineering Cohort participants during their Demo Days`}
 >
-  <CohortDropdown current={cohortLabel} />
-
   <section class="cohort-section">
     <div class="cohort-container">
-      <header class="mb-12 text-center">
+      <header class="cohort-header">
         <h1
-          class="text-4xl font-normal text-white"
+          class="cohort-title"
           style="font-family: 'IM Fell Double Pica', Times, serif;"
         >
-          {cohortLabel} Demo Day Projects
+          Demo Day Projects
         </h1>
+        <CohortDropdown current={cohortLabel} />
         {
           filtered.length > 0 && (
             <p class="mt-4 text-base text-zinc-400">
@@ -82,24 +82,17 @@ const isCurrentCohort = cohortLabel === COHORTS[COHORTS.length - 1];
       </header>
 
       {
-        filtered.length > 0 ? (
+        isCurrentCohort ? (
+          <DemoGallery client:load />
+        ) : filtered.length > 0 ? (
           <div class="cohort-masonry">
             {filtered.map((project) => (
               <ProjectCard project={project} />
             ))}
           </div>
         ) : (
-          <div class="rounded-2xl border border-dashed border-zinc-700 bg-zinc-950 p-12 text-center">
-            <p class="text-base font-medium text-zinc-200">
-              {isCurrentCohort
-                ? "This cohort is currently in progress."
-                : "No projects on record for this cohort."}
-            </p>
-            {isCurrentCohort && (
-              <p class="mt-2 text-sm text-zinc-400">
-                Demos will appear here as participants share them.
-              </p>
-            )}
+          <div class="cohort-empty">
+            <p>No projects on record for this cohort.</p>
           </div>
         )
       }
@@ -107,7 +100,9 @@ const isCurrentCohort = cohortLabel === COHORTS[COHORTS.length - 1];
   </section>
 </Base>
 
-<style>
+<style is:global>
+  /* Masonry styles are global so the React DemoGallery component on
+     the active cohort page can use the same layout classes. */
   .cohort-section {
     width: 100%;
     background: #000;
@@ -131,7 +126,7 @@ const isCurrentCohort = cohortLabel === COHORTS[COHORTS.length - 1];
   }
   .cohort-masonry {
     column-count: 1;
-    column-gap: 4rem;
+    column-gap: 1.25rem;
   }
   .cohort-masonry > * {
     break-inside: avoid;
@@ -139,18 +134,33 @@ const isCurrentCohort = cohortLabel === COHORTS[COHORTS.length - 1];
     page-break-inside: avoid;
     display: inline-block;
     width: 100%;
-    margin-bottom: 3.5rem;
+    margin-bottom: 1.25rem;
   }
   @media (min-width: 640px) {
     .cohort-masonry {
       column-count: 2;
-      column-gap: 5rem;
+      column-gap: 1.5rem;
     }
   }
   @media (min-width: 1024px) {
     .cohort-masonry {
       column-count: 3;
-      column-gap: 6rem;
+      column-gap: 1.75rem;
     }
+  }
+  /* Hide the native fullscreen button — our custom expand button replaces it */
+  .demo-video-thumb::-webkit-media-controls-fullscreen-button {
+    display: none !important;
+  }
+  .demo-video-thumb::-moz-media-controls-fullscreen-button {
+    display: none !important;
+  }
+  .cohort-empty {
+    border-radius: 1rem;
+    border: 1px dashed #3f3f46;
+    background: #09090b;
+    padding: 3rem;
+    text-align: center;
+    color: #d4d4d8;
   }
 </style>


### PR DESCRIPTION
## Summary

- **Per-cohort project pages**: each cohort (SEC-00 through SEC-07) now has its own URL at `/projects/secXX` with a masonry card layout. A dropdown under the page title lets visitors switch between cohorts and a "Highlights" view.
- **Live Nostr demo gallery on SEC-07**: the active cohort page pulls demo posts directly from Nostr via `applesauce-relay` instead of showing a static placeholder. Participants post a kind:1 note tagged `#demoday` from their npub and it appears automatically — no uploads, no admin step.
- **Highlights page**: `/projects` now shows only the 8 highlighted projects across all cohorts, with the same card layout.

## How the Nostr gallery works

1. A single multi-filter REQ queries 12 relays in parallel for cohort lists (kind:30000), demo events (kind:1 with `#demoday`), and author profiles (kind:0)
2. Posts are filtered by a hardcoded allowlist of 20 SEC-07 participant pubkeys (falls back until a curator publishes a kind:30000 list)
3. Date window filter: only posts between March 30 – April 20, 2026
4. Cards show avatar, name, video thumbnail, title, and "View on Nostr →" link
5. Custom video expand opens a phone-sized modal (375px) instead of native fullscreen

## New files

- `src/layouts/components/CohortDropdown.astro` — cohort selector dropdown
- `src/layouts/components/ProjectCard.astro` — card component for static projects
- `src/layouts/components/DemoGallery.tsx` — React component for live Nostr demos (hydrated `client:load`)
- `src/layouts/helpers/nostr/config.ts` — Nostr config (relays, hashtags, allowlist, dates)
- `src/layouts/helpers/nostr/NostrService.ts` — browser-side relay service via applesauce-relay
- `src/pages/projects/[cohort].astro` — dynamic route for per-cohort pages

## Dependencies added

- `applesauce-relay` (rxjs + nostr-tools come as transitive deps)

## Test plan

- [ ] Visit `/projects` — should show 8 highlighted projects in masonry cards
- [ ] Use dropdown to switch to SEC-01 — should show 21 project cards
- [ ] Visit `/projects/sec07` — should load live demos from Nostr (may take 1-2s)
- [ ] Post a kind:1 note tagged `#demoday` from an allowlisted npub and reload SEC-07
- [ ] Click the expand button (⛶) on a video — should open phone-sized modal
- [ ] Verify other cohort pages (sec00–sec06) still show their static projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)