### PR TITLE
Contest page: #SovEng social share title

### DIFF
--- a/src/pages/contest.astro
+++ b/src/pages/contest.astro
@@ -29,7 +29,7 @@ const sovEngUrl = "https://ants.sh/t/SovEng";
 
 <Base
   title="T-Shirt Design Contest"
-  meta_title="T-Shirt Design Contest"
+  meta_title="#SovEng T-Shirt Design Contest"
   description="Design the SEC-08 tee & win up to 1,000,000 sats! Submit on Nostr with #SovEng by June 15."
   image={heroImage}
   showCallToAction={true}


### PR DESCRIPTION
Updates the contest page `meta_title` so Open Graph and Twitter cards show `#SovEng T-Shirt Design Contest` when the `/contest` link is shared, matching the campaign hashtag without changing the on-page heading.

- Sets `meta_title` to `#SovEng T-Shirt Design Contest` in `src/pages/contest.astro`
- Drives `og:title`, `twitter:title`, and the document `<title>` via `Base.astro`
- On-page `<h1>` stays `T-Shirt Design Contest`

Build preview:
- [/contest](https://soveng2-git-tshirt-design-contest-followup-sov-eng.vercel.app/contest)
