### PR TITLE
feat: add fiatjaf quote to podcast page

### DIFF
--- a/src/layouts/components/BigBlockQuote.astro
+++ b/src/layouts/components/BigBlockQuote.astro
@@ -2,11 +2,12 @@
 interface Props {
   quote: string;
   author?: string;
+  authorHref?: string;
   href?: string;
   left?: boolean;
 }
 
-const { quote, author, href, left = false } = Astro.props;
+const { quote, author, authorHref, href, left = false } = Astro.props;
 ---
 
 <div class={`w-full flex ${left ? 'justify-start' : 'justify-center'} ${left ? 'py-0 mb-8' : 'py-8'} font-primary text-[#E5E7EB] italic text-2xl`}>
@@ -22,7 +23,15 @@ const { quote, author, href, left = false } = Astro.props;
     <blockquote class={`${left ? 'max-w-prose text-left' : 'max-w-3xl mx-auto text-center'} ${left ? '' : 'px-4'} text-balance`}>
       &ldquo;{quote}&rdquo;
       <br />
-      {author && <span>&mdash; {author}</span>}
+      {author && (
+        authorHref ? (
+          <a href={authorHref} class="no-underline hover:no-underline transition-colors duration-200 hover:text-primary focus:text-primary" target="_blank" rel="noopener noreferrer">
+            <span>&mdash; {author}</span>
+          </a>
+        ) : (
+          <span>&mdash; {author}</span>
+        )
+      )}
     </blockquote>
   )}
 </div>

--- a/src/pages/podcast/index.astro
+++ b/src/pages/podcast/index.astro
@@ -10,6 +10,13 @@ const metaParagraph =
 
 const metaQuote = `The conversations are real. Everything else is hallucinated.`;
 
+const fiatjafQuote = {
+  content: `Once it left its AI psychosis phase it has had some good moments.`,
+  author: `fiatjaf`,
+  authorHref: `https://njump.to/npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6`,
+  noteHref: `https://njump.to/nevent1qqsyeue9x26zdcrz2wx8stvl3kmxw42clqd5n4jgpuvxhemm6q8fyugprfmhxue69uhhq7tjv9kkjepwve5kzar2v9nzucm0d5hsygpm7rrrljungc6q0tuh5hj7ue863q73qlheu4vywtzwhx42a7j9n5psgqqqq3tszvt290`,
+};
+
 const pageTitle = "No Solutions";
 const metaTitle = "No Solutions — A Sovereign Engineering Podcast";
 const byline = `Walking towards a better internet since \
@@ -92,6 +99,37 @@ const episodes = await getEpisodes();
       <BigBlockQuote
         quote={metaQuote}
       />
+
+      <!-- Signed Social Proof -->
+      <div class="row justify-center mt-4 mb-8">
+        <div class="max-w-[960px] mx-auto w-full px-4">
+          <div class="border-2 border-primary bg-[#111] px-6 py-8 md:px-10 md:py-10 shadow-[8px_8px_0_0_rgba(255,102,0,0.18)]">
+            <p class="mb-4 text-center text-xs font-primary uppercase tracking-[0.35em] text-primary">Signed on Nostr</p>
+            <blockquote class="text-balance text-center font-primary text-2xl italic text-white md:text-3xl">
+              &ldquo;{fiatjafQuote.content}&rdquo;
+            </blockquote>
+            <div class="mt-6 flex flex-col items-center justify-center gap-2 text-center font-primary text-sm uppercase tracking-[0.2em] text-gray-400 sm:flex-row">
+              <a
+                href={fiatjafQuote.authorHref}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="text-white underline decoration-primary underline-offset-4 transition-colors hover:text-primary"
+              >
+                {fiatjafQuote.author}
+              </a>
+              <span class="hidden text-gray-600 sm:inline">•</span>
+              <a
+                href={fiatjafQuote.noteHref}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="underline decoration-gray-600 underline-offset-4 transition-colors hover:text-primary"
+              >
+                view signed note
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
 
       <!-- Episodes -->
       <div class="row justify-center">

--- a/src/pages/podcast/index.astro
+++ b/src/pages/podcast/index.astro
@@ -11,7 +11,7 @@ const metaParagraph =
 const fiatjafQuote = {
   content: `Once it left its AI psychosis phase it has had some good moments.`,
   author: `fiatjaf`,
-  authorHref: `https://njump.to/npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6`,
+  authorHref: `https://njump.to/nevent1qqsyeue9x26zdcrz2wx8stvl3kmxw42clqd5n4jgpuvxhemm6q8fyugprfmhxue69uhhq7tjv9kkjepwve5kzar2v9nzucm0d5hsygpm7rrrljungc6q0tuh5hj7ue863q73qlheu4vywtzwhx42a7j9n5psgqqqq3tszvt290`,
 };
 
 const pageTitle = "No Solutions";

--- a/src/pages/podcast/index.astro
+++ b/src/pages/podcast/index.astro
@@ -8,11 +8,10 @@ const metaParagraph =
   `No Solutions is a podcast about freedom tech, open protocols, and the trade-offs of building in the open. ` +
   `These are walking conversations with people trying to make the internet, and the world around it, a little more sovereign.`;
 
-const metaQuote = `The conversations are real. Everything else is hallucinated.`;
-
 const fiatjafQuote = {
   content: `Once it left its AI psychosis phase it has had some good moments.`,
   author: `fiatjaf`,
+  authorHref: `https://njump.to/npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6`,
 };
 
 const pageTitle = "No Solutions";
@@ -93,14 +92,10 @@ const episodes = await getEpisodes();
         </div>
       </div>
 
-      <!-- Centered Quote -->
-      <BigBlockQuote
-        quote={metaQuote}
-      />
-
       <BigBlockQuote
         quote={fiatjafQuote.content}
         author={fiatjafQuote.author}
+        authorHref={fiatjafQuote.authorHref}
       />
 
       <!-- Episodes -->

--- a/src/pages/podcast/index.astro
+++ b/src/pages/podcast/index.astro
@@ -13,8 +13,6 @@ const metaQuote = `The conversations are real. Everything else is hallucinated.`
 const fiatjafQuote = {
   content: `Once it left its AI psychosis phase it has had some good moments.`,
   author: `fiatjaf`,
-  authorHref: `https://njump.to/npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6`,
-  noteHref: `https://njump.to/nevent1qqsyeue9x26zdcrz2wx8stvl3kmxw42clqd5n4jgpuvxhemm6q8fyugprfmhxue69uhhq7tjv9kkjepwve5kzar2v9nzucm0d5hsygpm7rrrljungc6q0tuh5hj7ue863q73qlheu4vywtzwhx42a7j9n5psgqqqq3tszvt290`,
 };
 
 const pageTitle = "No Solutions";
@@ -100,36 +98,10 @@ const episodes = await getEpisodes();
         quote={metaQuote}
       />
 
-      <!-- Signed Social Proof -->
-      <div class="row justify-center mt-4 mb-8">
-        <div class="max-w-[960px] mx-auto w-full px-4">
-          <div class="border-2 border-primary bg-[#111] px-6 py-8 md:px-10 md:py-10 shadow-[8px_8px_0_0_rgba(255,102,0,0.18)]">
-            <p class="mb-4 text-center text-xs font-primary uppercase tracking-[0.35em] text-primary">Signed on Nostr</p>
-            <blockquote class="text-balance text-center font-primary text-2xl italic text-white md:text-3xl">
-              &ldquo;{fiatjafQuote.content}&rdquo;
-            </blockquote>
-            <div class="mt-6 flex flex-col items-center justify-center gap-2 text-center font-primary text-sm uppercase tracking-[0.2em] text-gray-400 sm:flex-row">
-              <a
-                href={fiatjafQuote.authorHref}
-                target="_blank"
-                rel="noopener noreferrer"
-                class="text-white underline decoration-primary underline-offset-4 transition-colors hover:text-primary"
-              >
-                {fiatjafQuote.author}
-              </a>
-              <span class="hidden text-gray-600 sm:inline">•</span>
-              <a
-                href={fiatjafQuote.noteHref}
-                target="_blank"
-                rel="noopener noreferrer"
-                class="underline decoration-gray-600 underline-offset-4 transition-colors hover:text-primary"
-              >
-                view signed note
-              </a>
-            </div>
-          </div>
-        </div>
-      </div>
+      <BigBlockQuote
+        quote={fiatjafQuote.content}
+        author={fiatjafQuote.author}
+      />
 
       <!-- Episodes -->
       <div class="row justify-center">


### PR DESCRIPTION
Replaces the podcast page quote with fiatjaf's quote and links the attribution to njump.

Tested with `npm run check` and `npm run build`.
