### PR TITLE
Redesign footer and streamline More menu

### DIFF
--- a/src/config/menu.json
+++ b/src/config/menu.json
@@ -17,86 +17,48 @@
       "url": "",
       "hasChildren": true,
       "children": [
-        { "name": "Projects", "url": "/projects" },
-        { "name": "Philosophy", "url": "/philosophy" },
         { "name": "Concept", "url": "/concept" },
-        { "name": "Loop", "url": "/loop" },
-        { "name": "Timeline", "url": "/timeline" },
+        { "name": "Philosophy", "url": "/philosophy" },
+        { "name": "Projects", "url": "/projects" },
         { "name": "Podcast", "url": "/podcast" },
-        { "name": "Books", "url": "/books" },
-        { "name": "FAQ", "url": "/faq" },
-        { "name": "Policy", "url": "/policy" },
-        {
-          "name": "Swag",
-          "url": "/swag"
-        },
-        {
-          "name": "Contest",
-          "url": "/contest"
-        },
-        {
-          "name": "Media",
-          "url": "/media"
-        },
-        {
-          "name": "Gallery",
-          "url": "https://slidestr.net/p/npub1s0veng2gvfwr62acrxhnqexq76sj6ldg3a5t935jy8e6w3shr5vsnwrmq5"
-        },
-        {
-          "name": "Videos",
-          "url": "https://castr.me/npub1s0veng2gvfwr62acrxhnqexq76sj6ldg3a5t935jy8e6w3shr5vsnwrmq5"
-        },
-        {
-          "name": "Alumni",
-          "url": "https://following.space/d/sier9e7ih6k2?p=83d999a148625c3d2bb819af3064c0f6a12d7da88f68b2c69221f3a746171d19"
-        }
+        { "name": "Media", "url": "/media" },
+        { "name": "Swag", "url": "/swag" },
+        { "name": "FAQ", "url": "/faq" }
       ]
     }
   ],
-  "footer": [
-    {
-      "name": "Philosophy",
-      "url": "/philosophy"
-    },
-    {
-      "name": "Projects",
-      "url": "/projects"
-    },
-    {
-      "name": "Concept",
-      "url": "/concept"
-    },
-    {
-      "name": "Loop",
-      "url": "/loop"
-    },
-    {
-      "name": "About",
-      "url": "https://njump.to/sovereignengineering.io"
-    },
-    {
-      "name": "Contact",
-      "url": "mailto:info@sovereignengineering.io"
-    },
-    {
-      "name": "FAQ",
-      "url": "/faq"
-    },
-    {
-      "name": "Swag",
-      "url": "/swag"
-    },
-    {
-      "name": "Contest",
-      "url": "/contest"
-    },
-    {
-      "name": "Alumni",
-      "url": "https://following.space/d/sier9e7ih6k2?p=83d999a148625c3d2bb819af3064c0f6a12d7da88f68b2c69221f3a746171d19"
-    },
-    {
-      "name": "Podcast",
-      "url": "/podcast"
-    }
-  ]
+  "footer": {
+    "sections": [
+      {
+        "title": "Program",
+        "links": [
+          { "name": "Concept", "url": "/concept" },
+          { "name": "Philosophy", "url": "/philosophy" },
+          { "name": "Loop", "url": "/loop" },
+          { "name": "Timeline", "url": "/timeline" }
+        ]
+      },
+      {
+        "title": "Resources",
+        "links": [
+          { "name": "Projects", "url": "/projects" },
+          { "name": "Podcast", "url": "/podcast" },
+          { "name": "Books", "url": "/books" },
+          { "name": "FAQ", "url": "/faq" }
+        ]
+      },
+      {
+        "title": "Community",
+        "links": [
+          { "name": "Swag", "url": "/swag" },
+          { "name": "Contest", "url": "/contest" },
+          { "name": "Media", "url": "/media" },
+          {
+            "name": "Alumni",
+            "url": "https://following.space/d/sier9e7ih6k2?p=83d999a148625c3d2bb819af3064c0f6a12d7da88f68b2c69221f3a746171d19"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/src/content/faq/-index.md
+++ b/src/content/faq/-index.md
@@ -16,6 +16,7 @@ intro:
     - [What is the cost of living in Madeira?](#what-is-the-cost-of-living-in-madeira)
     - [How do I best contact you?](#how-do-i-best-contact-you)
     - [How do I apply?](#how-do-i-apply)
+    - [What is your selection policy?](#what-is-your-selection-policy)
 
 # FAQ sections
 sections:
@@ -54,6 +55,9 @@ sections:
     questions:
       - question: 'How do I apply?'
         answer: 'Applications for SEC-08 are open. Apply via the [upcoming cohorts](/#upcoming-cohorts) section on the homepage.'
+
+      - question: 'What is your selection policy?'
+        answer: 'We select participants based on merit, public proof-of-work, and alignment with our philosophy. Read our full [policies and guidelines](/policy) for details on selection, non-discrimination, and partnerships.'
 
       - question: 'How do I best contact you?'
         answer: "You can contact us via email [info@sovereignengineering.io](mailto:info@sovereignengineering.io) or via [nostr](https://njump.me/sovereignengineering.io). We'll do our best to get back to you as soon as possible."

--- a/src/layouts/partials/Footer.astro
+++ b/src/layouts/partials/Footer.astro
@@ -4,102 +4,122 @@ import config from "@/config/config.json";
 import menu from "@/config/menu.json";
 import social from "@/config/social.json";
 import { markdownify } from "@/lib/utils/textConverter";
-import { getFooterMenuItems } from "@/lib/utils/menuItems";
+import {
+  getFooterSections,
+  isExternalUrl,
+  type MenuItem,
+} from "@/lib/utils/menuItems";
 
-// Use the same menu items as mobile nav
-const footerMenuItems = getFooterMenuItems(menu);
+const footerSections = getFooterSections(menu);
 ---
 
-<footer class="bg-black text-white border-t border-primary">
-  <div class="container py-10">
-    <!-- Mobile and Medium Width Layout -->
-    <div class="lg:hidden">
-      <!-- Logo and Brand -->
-      <div class="text-center mb-6">
-        <div class="flex items-center justify-center mb-4">
-          <img src="/images/sec-05-sec-05-brandmark-white-rgb.svg" alt="Sovereign Engineering" class="w-10 h-10 mr-3" />
-          <a href="https://nostr.band/?q=%23SovEng" target="_blank" rel="noopener" class="text-white font-bold hover:text-primary transition-colors text-xl">#SovEng</a>
-        </div>
+<footer class="site-footer">
+  <div class="site-footer__glow" aria-hidden="true"></div>
 
-        <!-- Navigation Links -->
-        <nav class="mb-6">
-          <ul class="grid grid-cols-2 gap-1 max-w-xs mx-auto">
-            {
-              footerMenuItems.map((menuItem) => {
-                const isExternal = menuItem.url.startsWith('http') || menuItem.url.startsWith('mailto');
-                return (
-                  <li>
-                    <a
-                      href={menuItem.url}
-                      class="text-white hover:text-primary hover:bg-white/10 transition-all py-2 px-4 text-base flex items-center justify-between"
-                      style="font-family: 'IM Fell Double Pica', Times, serif;"
-                      {...(isExternal && { target: "_blank", rel: "noopener noreferrer" })}
-                    >
-                      <span>{menuItem.name}</span>
-                      {isExternal && (
-                        <svg class="w-4 h-4 opacity-60" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                          <path d="M13 5H19V11"/>
-                          <path d="M19 5L5 19"/>
-                        </svg>
-                      )}
-                    </a>
-                  </li>
-                );
-              })
-            }
-          </ul>
-        </nav>
-
-        <!-- Social Icons -->
-        <div class="flex justify-center items-center gap-4">
-          <Social source={social.main} className="social-icons text-white" />
-        </div>
+  <div class="container site-footer__main">
+    <div class="site-footer__grid">
+      <div class="site-footer__brand hidden md:flex">
+        <a
+          href="https://ants.sh/t/SovEng"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="site-footer__brand-link"
+        >
+          <img
+            src="/images/sec-05-sec-05-brandmark-white-rgb.svg"
+            alt=""
+            class="site-footer__mark"
+            width="40"
+            height="40"
+          />
+          <span class="site-footer__brand-name">Sovereign Engineering</span>
+        </a>
       </div>
-    </div>
 
-    <!-- Desktop Layout -->
-    <div class="hidden lg:block">
-      <div class="flex items-center justify-between">
-        <div class="flex items-center">
-          <img src="/images/sec-05-sec-05-brandmark-white-rgb.svg" alt="Sovereign Engineering" class="w-8 h-8 mr-3" />
-          <a href="https://nostr.band/?q=%23SovEng" target="_blank" rel="noopener" class="text-white font-bold hover:text-primary transition-colors">#SovEng</a>
-        </div>
+      <nav class="site-footer__sitemap" aria-label="Footer sitemap">
+        {
+          footerSections.map((section) => (
+            <div class="site-footer__section">
+              <p class="site-footer__label">{section.title}</p>
+              <ul class="site-footer__links">
+                {section.links.map((link: MenuItem) => {
+                  const isExternal = isExternalUrl(link.url);
+                  return (
+                    <li>
+                      <a
+                        href={link.url}
+                        class="site-footer__link"
+                        {...(isExternal && {
+                          target: "_blank",
+                          rel: "noopener noreferrer",
+                        })}
+                      >
+                        <span>{link.name}</span>
+                        {isExternal && (
+                          <svg
+                            class="site-footer__external"
+                            xmlns="http://www.w3.org/2000/svg"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            aria-hidden="true"
+                          >
+                            <path d="M13 5H19V11" />
+                            <path d="M19 5L5 19" />
+                          </svg>
+                        )}
+                      </a>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          ))
+        }
+      </nav>
 
-        <nav class="flex-1 mx-8">
-          <ul class="flex flex-wrap justify-center items-center gap-x-6 gap-y-2">
-            {
-              footerMenuItems.map((menuItem) => {
-                const isExternal = menuItem.url.startsWith('http') || menuItem.url.startsWith('mailto');
-                return (
-                  <li>
-                    <a
-                      href={menuItem.url}
-                      class="text-white hover:text-primary transition-colors inline-flex items-center"
-                      {...(isExternal && { target: "_blank", rel: "noopener noreferrer" })}
-                    >
-                      <span>{menuItem.name}</span>
-                      {isExternal && (
-                        <svg class="w-3 h-3 ml-1 opacity-60" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                          <path d="M13 5H19V11"/>
-                          <path d="M19 5L5 19"/>
-                        </svg>
-                      )}
-                    </a>
-                  </li>
-                );
-              })
-            }
-          </ul>
-        </nav>
-
-        <div class="flex items-center gap-3">
-          <Social source={social.main} className="social-icons text-white" />
+      <div class="site-footer__connect">
+        <p class="site-footer__label">Connect</p>
+        <Social source={social.main} className="site-footer__social" />
+        <div class="site-footer__contact-links">
+          <a
+            href="mailto:info@sovereignengineering.io"
+            class="site-footer__contact-link"
+          >
+            info@sovereignengineering.io
+          </a>
+          <a
+            href="https://njump.to/sovereignengineering.io"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="site-footer__contact-link"
+          >
+            @sovereignengineering.io
+            <svg
+              class="site-footer__external"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M13 5H19V11" />
+              <path d="M19 5L5 19" />
+            </svg>
+          </a>
         </div>
       </div>
     </div>
   </div>
-  <div class="border-t border-primary py-7">
-    <div class="container text-center text-white content">
+
+  <div class="site-footer__bar">
+    <div class="container site-footer__copyright content">
       <p set:html={markdownify(config.params.copyright)} />
     </div>
   </div>

--- a/src/lib/utils/menuItems.ts
+++ b/src/lib/utils/menuItems.ts
@@ -1,4 +1,3 @@
-// Single source of truth for menu items
 export interface MenuItem {
   name: string;
   url: string;
@@ -7,25 +6,31 @@ export interface MenuItem {
   children?: MenuItem[];
 }
 
+export interface FooterSection {
+  title: string;
+  links: MenuItem[];
+}
+
 export interface Menu {
   main: MenuItem[];
-  footer: MenuItem[];
+  footer: {
+    sections: FooterSection[];
+  };
 }
 
 export function getAllMenuItems(menu: Menu): MenuItem[] {
   const { main } = menu;
 
-  // Get all items from the "More" dropdown
-  const moreItems = main.find((item: MenuItem) => item.name === 'More')?.children || [];
+  const moreItems =
+    main.find((item: MenuItem) => item.name === "More")?.children || [];
 
-  // Return items in the order they appear in the mobile nav
   return moreItems;
 }
 
-export function getFooterMenuItems(menu: Menu): MenuItem[] {
-  // Get all items from the "More" dropdown but exclude Gallery, Videos, and Policy
-  // since Gallery and Videos are already covered by social media buttons
-  // and Policy should only appear in the main menu
-  const allItems = getAllMenuItems(menu);
-  return allItems.filter((item) => item.name !== 'Gallery' && item.name !== 'Videos' && item.name !== 'Policy');
+export function getFooterSections(menu: Menu): FooterSection[] {
+  return menu.footer.sections;
+}
+
+export function isExternalUrl(url: string): boolean {
+  return url.startsWith("http") || url.startsWith("mailto");
 }

--- a/src/lib/utils/menuItems.ts
+++ b/src/lib/utils/menuItems.ts
@@ -21,8 +21,7 @@ export interface Menu {
 export function getAllMenuItems(menu: Menu): MenuItem[] {
   const { main } = menu;
 
-  const moreItems =
-    main.find((item: MenuItem) => item.name === "More")?.children || [];
+  const moreItems = main.find((item: MenuItem) => item.name === 'More')?.children || [];
 
   return moreItems;
 }
@@ -32,5 +31,5 @@ export function getFooterSections(menu: Menu): FooterSection[] {
 }
 
 export function isExternalUrl(url: string): boolean {
-  return url.startsWith("http") || url.startsWith("mailto");
+  return url.startsWith('http') || url.startsWith('mailto');
 }

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -281,3 +281,221 @@
   height: auto;
   object-fit: contain;
 }
+
+/* footer */
+.site-footer {
+  position: relative;
+  overflow: hidden;
+  border-top: 3px solid var(--color-primary, #ed3238);
+  background: #000;
+  color: #fff;
+}
+
+.site-footer__glow {
+  pointer-events: none;
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(
+      ellipse 70% 55% at 0% 100%,
+      rgba(237, 50, 56, 0.1),
+      transparent 65%
+    ),
+    radial-gradient(
+      ellipse 45% 40% at 100% 0%,
+      rgba(255, 255, 255, 0.03),
+      transparent 70%
+    );
+}
+
+.site-footer__main {
+  position: relative;
+  z-index: 1;
+  padding-block: 3rem 2.75rem;
+}
+
+.site-footer__grid {
+  display: grid;
+  gap: 2.25rem;
+}
+
+@media (min-width: 1024px) {
+  .site-footer__grid {
+    grid-template-columns: minmax(200px, 1fr) minmax(0, 2.2fr) minmax(180px, 1fr);
+    gap: 2.5rem 3rem;
+    align-items: start;
+  }
+}
+
+.site-footer__sitemap {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.75rem;
+}
+
+@media (min-width: 480px) {
+  .site-footer__sitemap {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1.75rem 2rem;
+  }
+}
+
+@media (min-width: 768px) {
+  .site-footer__sitemap {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.site-footer__section {
+  min-width: 0;
+}
+
+.site-footer__brand {
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.site-footer__brand-link {
+  display: flex;
+  align-items: center;
+  gap: 0.875rem;
+  color: #fff;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.site-footer__brand-link:hover {
+  color: var(--color-primary, #ed3238);
+}
+
+.site-footer__mark {
+  flex-shrink: 0;
+  width: 2.5rem;
+  height: 2.5rem;
+  transition: transform 0.25s ease;
+}
+
+.site-footer__brand-link:hover .site-footer__mark {
+  transform: rotate(-4deg) scale(1.04);
+}
+
+.site-footer__brand-name {
+  font-family: var(--font-secondary);
+  font-size: 1.125rem;
+  line-height: 1.2;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.site-footer__label {
+  margin: 0 0 1rem;
+  color: var(--color-primary, #ed3238);
+  font-family: var(--font-secondary);
+  font-size: 0.75rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.site-footer__links {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.site-footer__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0;
+  color: #fff;
+  font-family: var(--font-secondary);
+  font-size: 1rem;
+  line-height: 1.35;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.site-footer__link:hover {
+  color: var(--color-primary, #ed3238);
+}
+
+.site-footer__external {
+  width: 0.75rem;
+  height: 0.75rem;
+  flex-shrink: 0;
+  opacity: 0.55;
+}
+
+.site-footer__connect {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.site-footer__social {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.site-footer__social li {
+  display: inline-block;
+}
+
+.site-footer__contact-links {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.site-footer__contact-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: #b4afb6;
+  font-family: var(--font-primary);
+  font-size: 0.9375rem;
+  line-height: 1.45;
+  text-decoration: none;
+  transition: color 0.2s ease;
+  word-break: break-word;
+}
+
+.site-footer__contact-link:hover {
+  color: #fff;
+  text-decoration: underline;
+  text-underline-offset: 0.2em;
+}
+
+.site-footer__bar {
+  position: relative;
+  z-index: 1;
+  border-top: 1px solid rgba(237, 50, 56, 0.28);
+  background: rgba(255, 255, 255, 0.02);
+  padding: 1.25rem 0 1.5rem;
+}
+
+.site-footer__copyright {
+  text-align: center;
+}
+
+.site-footer__copyright p {
+  margin: 0;
+  color: #b4afb6;
+  font-size: 0.9375rem;
+  line-height: 1.6;
+}
+
+.site-footer__copyright a {
+  color: #e5e7eb;
+  text-decoration: underline;
+  text-underline-offset: 0.18em;
+  transition: color 0.2s ease;
+}
+
+.site-footer__copyright a:hover {
+  color: var(--color-primary, #ed3238);
+}


### PR DESCRIPTION
Redesigns the site footer into a grouped sitemap (Program, Resources, Community) with a Connect column, fixes mobile padding, and trims the More dropdown to a shorter curated list while moving policy discovery to the FAQ.

- Footer links are grouped in `menu.json` sections with responsive vertical lists instead of a single cramped row
- More menu drops redundant entries (Policy, Contest, Gallery, Videos, Alumni, Loop, Timeline, Books) kept elsewhere in footer or FAQ
- Connect shows `@sovereignengineering.io` NIP-05; brand block hidden on mobile and links to ants.sh/t/SovEng

Build preview:
- [/](https://soveng2-git-better-footer-and-menu-sov-eng.vercel.app/)
- [/faq](https://soveng2-git-better-footer-and-menu-sov-eng.vercel.app/faq)
