### PR TITLE
feat: close SEC-08 applications

### DIFF
--- a/src/content/sections/call-to-action.md
+++ b/src/content/sections/call-to-action.md
@@ -1,11 +1,11 @@
 ---
 enable: true
-title: 'Ready for adventure?'
+title: 'Applications are now closed'
 image: '/images/men-wanted.png'
-description: "Experience, build, and alpha-test the future of self-sovereign technology in beautiful Madeira. Don't miss the opportunity of a lifetime."
+description: 'Thank you for your interest in Sovereign Engineering. Applications for SEC-08 are now closed. Stay tuned for future opportunities to join our community of builders.'
 button:
-  enable: true
+  enable: false
   label: 'Apply Now!'
   link: 'https://sovereignengineering.typeform.com/SEC-08'
-dates: 'Jul 20 - Aug 28'
+dates: ''
 ---

--- a/src/content/sections/upcoming-cohorts.md
+++ b/src/content/sections/upcoming-cohorts.md
@@ -20,6 +20,7 @@ cohorts:
     description: 'YOLO++'
     duration: '6 weeks'
     dates: 'starting July 20'
+    closed: true
     link: 'https://sovereignengineering.typeform.com/SEC-08'
     blogLink: 'https://primal.net/soveng/sec-08-yolo'
 ---


### PR DESCRIPTION
Closes SEC-08 applications now that the cohort intake is over. The SEC-08 entry in the upcoming cohorts list is marked as closed, and the homepage call-to-action is switched to the standard "applications closed" state so visitors are no longer pointed at a live application form.

- Add `closed: true` to SEC-08 in `upcoming-cohorts.md` so it renders "Applications closed"
- Update `call-to-action.md` title and copy, and set `button.enable: false` to hide the Apply Now button

Build preview:
- [/](https://soveng2-git-close-applications-sec08-sov-eng.vercel.app/)
- [/#upcoming-cohorts](https://soveng2-git-close-applications-sec08-sov-eng.vercel.app/#upcoming-cohorts)
