### PR TITLE
fix: add page-specific social metadata

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -18,6 +18,7 @@ import {
   GoogleTagmanagerNoscript,
 } from "@digi4care/astro-google-tagmanager";
 import { ClientRouter } from "astro:transitions";
+import type { ImageMetadata } from "astro";
 import type { CollectionEntry } from "astro:content";
 import { getEntry } from "astro:content";
 
@@ -30,14 +31,15 @@ export interface Props {
   title?: string;
   meta_title?: string;
   description?: string;
-  image?: string;
+  image?: string | ImageMetadata;
+  image_alt?: string;
   noindex?: boolean;
   canonical?: string;
   showCallToAction?: boolean;
 }
 
 // destructure frontmatter
-const { title, meta_title, description, image, noindex, canonical, showCallToAction = true } =
+const { title, meta_title, description, image, image_alt, noindex, canonical, showCallToAction = true } =
   Astro.props;
 
 // process text content
@@ -45,6 +47,15 @@ const processedTitle = await plainify(meta_title ? meta_title : title ? title : 
 const processedDescription = await plainify(
   description ? description : config.metadata.meta_description
 );
+const socialImage = typeof image === "string" ? image : image?.src;
+const socialImagePath = socialImage || config.metadata.meta_image;
+const socialImageUrl = socialImagePath.startsWith("http")
+  ? socialImagePath
+  : new URL(socialImagePath, config.site.base_url).toString();
+const canonicalUrl = canonical
+  ? canonical
+  : new URL(Astro.url.pathname, config.site.base_url).toString();
+const processedImageAlt = await plainify(image_alt || title || config.site.title);
 
 // Get call-to-action data if needed
 const call_to_action = showCallToAction ? (await getEntry(
@@ -113,7 +124,7 @@ const call_to_action = showCallToAction ? (await getEntry(
     </title>
 
     <!-- canonical url -->
-    {canonical && <link rel="canonical" href={canonical} item-prop="url" />}
+    <link rel="canonical" href={canonicalUrl} item-prop="url" />
 
     <!-- noindex robots -->
     {noindex && <meta name="robots" content="noindex,nofollow" />}
@@ -151,7 +162,7 @@ const call_to_action = showCallToAction ? (await getEntry(
     <meta property="og:type" content="website" />
     <meta
       property="og:url"
-      content={`${config.site.base_url}/${Astro.url.pathname.replace("/", "")}`}
+      content={canonicalUrl}
     />
 
     <!-- twitter-title -->
@@ -169,20 +180,16 @@ const call_to_action = showCallToAction ? (await getEntry(
     <!-- og-image -->
     <meta
       property="og:image"
-      content={(() => {
-        const img = image || config.metadata.meta_image;
-        return img.startsWith('http') ? img : `${config.site.base_url}${img}`;
-      })()}
+      content={socialImageUrl}
     />
+    <meta property="og:image:secure_url" content={socialImageUrl} />
 
     <!-- twitter-image -->
     <meta
       name="twitter:image"
-      content={(() => {
-        const img = image || config.metadata.meta_image;
-        return img.startsWith('http') ? img : `${config.site.base_url}${img}`;
-      })()}
+      content={socialImageUrl}
     />
+    <meta name="twitter:image:alt" content={processedImageAlt} />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@sovereigneng" />
     <meta name="twitter:creator" content="@dergigi" />
@@ -192,7 +199,7 @@ const call_to_action = showCallToAction ? (await getEntry(
     <meta property="og:locale" content="en_US" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
-    <meta property="og:image:alt" content={processedTitle} />
+    <meta property="og:image:alt" content={processedImageAlt} />
 
     <!-- Structured Data -->
     <script type="application/ld+json" is:inline>

--- a/src/pages/books.astro
+++ b/src/pages/books.astro
@@ -5,7 +5,11 @@ import type { Book, Link } from "@/types";
 const page_title = "Books";
 ---
 
-<Base title={page_title}>
+<Base
+  title={page_title}
+  image="/images/books/on-dialogue.jpg"
+  image_alt="On Dialogue book cover"
+>
   <section class="section">
     <div class="container">
       <div class="row mb-8 justify-center">

--- a/src/pages/concept.astro
+++ b/src/pages/concept.astro
@@ -111,6 +111,8 @@ const processedSections = sections.map(
   title={title}
   meta_title={meta_title}
   description={description}
+  image={intro.image ? slideMap[intro.image] : ""}
+  image_alt="The Sovereign Engineering path through six weeks in Madeira"
 >
   <!-- Intro Lead Section -->
   <ContentLead

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -36,6 +36,8 @@ interface Section {
   title={title}
   meta_title={meta_title}
   description={description}
+  image={funchalImage}
+  image_alt="Funchal, Madeira"
 >
   <!-- Intro Lead Section -->
   <ContentLead

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -52,7 +52,11 @@ const { banner, features } = homepage.data as Homepage;
 const bannerTitle = await markdownify(banner.title);
 ---
 
-<Base showCallToAction={false}>
+<Base
+  showCallToAction={false}
+  image="/images/shining-city-in-cyberspace.png"
+  image_alt="A person looking toward a shining city in cyberspace"
+>
   <!-- Hero Section -->
   <header class="h-screen w-full flex flex-col text-white relative bg-primary font-primary text-lg">
     <!-- Top Navigation / Logo Row -->

--- a/src/pages/loop.astro
+++ b/src/pages/loop.astro
@@ -58,6 +58,8 @@ const imageMap: Record<string, ImageMetadata | string> = {
   title={title}
   meta_title={meta_title}
   description={description}
+  image={showTalkBuildLoopImage}
+  image_alt="The Sovereign Engineering show, talk, build loop"
 >
   <!-- Intro Lead Section -->
   <ContentLead

--- a/src/pages/philosophy.astro
+++ b/src/pages/philosophy.astro
@@ -13,6 +13,7 @@ import slideWideOpenSea from "@/assets/images/wide-open-sea.jpeg";
 import slideBellLabs from "@/assets/images/bell-labs.jpeg";
 import slideSolvitur from "@/assets/images/solvitur-ambulando.jpeg";
 import slideGenesisBlock from "@/assets/images/genesis-block.png";
+import schoolOfAthensImage from "@/assets/images/school-of-athens.jpeg";
 import philosophyQuotes from "@/data/philosophy-quotes.json";
 
 import type { CollectionEntry } from "astro:content";
@@ -63,6 +64,8 @@ interface Section {
   title={title}
   meta_title={meta_title}
   description={description}
+  image={schoolOfAthensImage}
+  image_alt="The School of Athens fresco by Raphael"
 >
   <!-- Intro Lead Section -->
   <ContentLead

--- a/src/pages/policy.astro
+++ b/src/pages/policy.astro
@@ -43,6 +43,8 @@ interface Section {
   title={title}
   meta_title={meta_title}
   description={description}
+  image={schoolOfAthensSketchImage}
+  image_alt="Sketch of the School of Athens"
 >
   <!-- Intro Lead Section -->
   <ContentLead

--- a/src/pages/swag.astro
+++ b/src/pages/swag.astro
@@ -6,6 +6,8 @@ import Base from "@/layouts/Base.astro";
   title="Swag"
   meta_title="Sovereign Engineering Swag"
   description="Get your Sovereign Engineering merchandise - shirts, hoodies, and more"
+  image="/images/swag/black-hat.webp"
+  image_alt="Sovereign Engineering black hat design"
   showCallToAction={false}
 >
   <!-- Hero Section with Black Hat Image -->

--- a/src/pages/timeline.astro
+++ b/src/pages/timeline.astro
@@ -104,7 +104,13 @@ const milestones: Milestone[] = [
 ];
 ---
 
-<Base title={pageTitle} meta_title={metaTitle} description={pageDescription}>
+<Base
+  title={pageTitle}
+  meta_title={metaTitle}
+  description={pageDescription}
+  image="/images/SEC-08-smp.webp"
+  image_alt="Sovereign Engineering SEC-08"
+>
   <section class="section-sm bg-black text-white pt-[8rem]">
     <div class="container">
       <!-- Header -->


### PR DESCRIPTION
Closes #120. Adds specific social metadata for key pages so shared links no longer fall back to the current cohort banner image. The shared `Base` layout now resolves public image paths and Astro image imports into absolute social image URLs, emits canonical URLs by default, and supports page-specific image alt text.

- Sets dedicated `og:image` and Twitter images for `/loop`, `/concept`, `/philosophy`, `/swag`, and other top-level pages
- Uses Raphael's School of Athens image for `/philosophy`
- Keeps the existing podcast and project metadata behavior intact
---
**Build preview:**
- [/loop](https://soveng2-git-fix-page-og-images-sov-eng.vercel.app/loop)
- [/concept](https://soveng2-git-fix-page-og-images-sov-eng.vercel.app/concept)
- [/philosophy](https://soveng2-git-fix-page-og-images-sov-eng.vercel.app/philosophy)
- [/swag](https://soveng2-git-fix-page-og-images-sov-eng.vercel.app/swag)
